### PR TITLE
Fix SBT download

### DIFF
--- a/sbt
+++ b/sbt
@@ -10,7 +10,7 @@ SBT="sbt-launch-$SBT_VERSION.jar"
 SBT_URL="http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar"
 
 if [ ! -e $SBT ]; then
-    $CURL -o $SBT -s $SBT_URL
+    $CURL -L -o $SBT -s $SBT_URL
 fi
 
 $JAVA $JAVA_OPTS -jar $SBT "$@"


### PR DESCRIPTION
Although the SBT download URL is still valid, it responds with a HTTP redirection nowadays. Use the `-L`/`--location` option to make `curl` follow HTTP redirections.